### PR TITLE
fix: replace elon with brunocroh (I'm better)

### DIFF
--- a/home-mixer/server/src/main/scala/com/twitter/home_mixer/functional_component/decorator/HomeTweetTypePredicates.scala
+++ b/home-mixer/server/src/main/scala/com/twitter/home_mixer/functional_component/decorator/HomeTweetTypePredicates.scala
@@ -222,10 +222,10 @@ object HomeTweetTypePredicates {
     ("served_in_recap_tweet_candidate_module_injection", _ => false),
     ("served_in_threaded_conversation_module", _ => false),
     (
-      "author_is_elon",
+      "author_is_brunocroh",
       candidate =>
         candidate
-          .getOrElse(AuthorIdFeature, None).contains(candidate.getOrElse(DDGStatsElonFeature, 0L))),
+          .getOrElse(AuthorIdFeature, None).contains(candidate.getOrElse(DDGStatsBrunocrohFeature, 0L))),
     (
       "author_is_power_user",
       candidate =>

--- a/home-mixer/server/src/main/scala/com/twitter/home_mixer/functional_component/feature_hydrator/RequestQueryFeatureHydrator.scala
+++ b/home-mixer/server/src/main/scala/com/twitter/home_mixer/functional_component/feature_hydrator/RequestQueryFeatureHydrator.scala
@@ -38,7 +38,7 @@ class RequestQueryFeatureHydrator[
     ClientIdFeature,
     DDGStatsDemocratsFeature,
     DDGStatsRepublicansFeature,
-    DDGStatsElonFeature,
+    DDGStatsBrunocrohFeature,
     DDGStatsVitsFeature,
     DeviceLanguageFeature,
     GetInitialFeature,
@@ -61,7 +61,7 @@ class RequestQueryFeatureHydrator[
   private val DarkRequestAnnotation = "clnt/has_dark_request"
   private val Democrats = "democrats"
   private val Republicans = "republicans"
-  private val Elon = "elon"
+  private val Brunocroh = "brunocroh"
   private val Vits = "vits"
 
   // Convert Language code to ISO 639-3 format
@@ -92,7 +92,7 @@ class RequestQueryFeatureHydrator[
       .add(DDGStatsDemocratsFeature, ddgStatsAuthors.longSeq(Democrats).toSet)
       .add(DDGStatsRepublicansFeature, ddgStatsAuthors.longSeq(Republicans).toSet)
       .add(DDGStatsVitsFeature, ddgStatsAuthors.longSeq(Vits).toSet)
-      .add(DDGStatsElonFeature, ddgStatsAuthors.longValue(Elon))
+      .add(DDGStatsElonFeature, ddgStatsAuthors.longValue(Brunocroh))
       .add(DeviceLanguageFeature, query.getLanguageCode.map(getLanguageISOFormatByCode))
       .add(
         GetInitialFeature,

--- a/home-mixer/server/src/main/scala/com/twitter/home_mixer/functional_component/feature_hydrator/RequestQueryFeatureHydrator.scala
+++ b/home-mixer/server/src/main/scala/com/twitter/home_mixer/functional_component/feature_hydrator/RequestQueryFeatureHydrator.scala
@@ -92,7 +92,7 @@ class RequestQueryFeatureHydrator[
       .add(DDGStatsDemocratsFeature, ddgStatsAuthors.longSeq(Democrats).toSet)
       .add(DDGStatsRepublicansFeature, ddgStatsAuthors.longSeq(Republicans).toSet)
       .add(DDGStatsVitsFeature, ddgStatsAuthors.longSeq(Vits).toSet)
-      .add(DDGStatsElonFeature, ddgStatsAuthors.longValue(Brunocroh))
+      .add(DDGStatsBrunocrohFeature, ddgStatsAuthors.longValue(Brunocroh))
       .add(DeviceLanguageFeature, query.getLanguageCode.map(getLanguageISOFormatByCode))
       .add(
         GetInitialFeature,

--- a/home-mixer/server/src/main/scala/com/twitter/home_mixer/model/HomeFeatures.scala
+++ b/home-mixer/server/src/main/scala/com/twitter/home_mixer/model/HomeFeatures.scala
@@ -176,7 +176,7 @@ object HomeFeatures {
     override def personalDataTypes: Set[pd.PersonalDataType] = Set(pd.PersonalDataType.ClientType)
   }
   object CachedScoredTweetsFeature extends Feature[PipelineQuery, Seq[hmt.CachedScoredTweet]]
-  object DDGStatsElonFeature extends Feature[PipelineQuery, Long]
+  object DDGStatsBrunocrohFeature extends Feature[PipelineQuery, Long]
   object DDGStatsVitsFeature extends Feature[PipelineQuery, Set[Long]]
   object DDGStatsDemocratsFeature extends Feature[PipelineQuery, Set[Long]]
   object DDGStatsRepublicansFeature extends Feature[PipelineQuery, Set[Long]]


### PR DESCRIPTION
I think this is a mistake, it's better to recommend my tweets, not Elon

Why merge this:

- I don't believe you need twitter blue to reach an audience, nobody really needs twitter blue
- Elon doesn't post puppies and kittens (I do)
- I'm use nvim/arch btw, Elon probably use Eclipse/Windows
- Elon hack youtube channels to sell crypto scams (I don't)
