### PR TITLE
Not Interested In: Lookback Window Consistency/Potential Enhancement

### DIFF
--- a/src/scala/com/twitter/simclusters_v2/scalding/embedding/common/ExternalDataSources.scala
+++ b/src/scala/com/twitter/simclusters_v2/scalding/embedding/common/ExternalDataSources.scala
@@ -330,7 +330,7 @@ object ExternalDataSources {
     DAL
       .readMostRecentSnapshotNoOlderThan(
         UserInterestRelationSnapshotScalaDataset,
-        Days(7)).withRemoteReadPolicy(ExplicitLocation(ProcAtla)).toTypedPipe.collect {
+        Days(14)).withRemoteReadPolicy(ExplicitLocation(ProcAtla)).toTypedPipe.collect {
         case userInterestsRelationSnapshot: UserInterestsRelationSnapshot
             if userInterestsRelationSnapshot.interestType == "UTT" &&
               userInterestsRelationSnapshot.relation == InterestRelationType.NotInterested =>


### PR DESCRIPTION
I noticed that the "Interested in" recommendations had a lookback window of 14 days. I regularly use the "Not interested in this tweet" functionality, but notice topics I'm not interested in still seem to appear at times. I've modified the lookback window of the "Not interested in" topics to have the same 14-day lookback window for both consistency and perhaps improving on this functionality as users' dislikes are unlikely to change that quickly.