### PR TITLE
prefer folds over pattern matching

### DIFF
--- a/ann/src/main/scala/com/twitter/ann/hnsw/JMapBasedIdEmbeddingMap.scala
+++ b/ann/src/main/scala/com/twitter/ann/hnsw/JMapBasedIdEmbeddingMap.scala
@@ -44,10 +44,7 @@ private[hnsw] object JMapBasedIdEmbeddingMap {
     injection: Injection[T, Array[Byte]],
     numElements: Option[Int] = Option.empty
   ): IdEmbeddingMap[T] = {
-    val map = numElements match {
-      case Some(elements) => new ConcurrentHashMap[T, EmbeddingVector](elements)
-      case None => new ConcurrentHashMap[T, EmbeddingVector]()
-    }
+    val map = numElements.fold(new ConcurrentHashMap[T, EmbeddingVector])(elems => new ConcurrentHashMap(elems))
     HnswIOUtil.loadEmbeddings(
       embeddingFile,
       injection,


### PR DESCRIPTION
pattern matching boilerplate:
```scala
val strResult = Option(5) match { 
  case Some(v) => v.toString
  case None => "0"
}
```

fold:
```scala
val strResult = Option(5).fold("0")(_.toString)
```