### PR TITLE
Refactor `navi/segdense`

### DIFF
--- a/navi/segdense/src/error.rs
+++ b/navi/segdense/src/error.rs
@@ -5,39 +5,49 @@ use std::fmt::Display;
  */
 #[derive(Debug)]
 pub enum SegDenseError {
-  IoError(std::io::Error),
-  Json(serde_json::Error),
-  JsonMissingRoot,
-  JsonMissingObject,
-  JsonMissingArray,
-  JsonArraySize,
-  JsonMissingInputFeature,
+    IoError(std::io::Error),
+    Json(serde_json::Error),
+    JsonMissingRoot,
+    JsonMissingObject,
+    JsonMissingArray,
+    JsonArraySize,
+    JsonMissingInputFeature,
 }
 
 impl Display for SegDenseError {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    match self {
-      SegDenseError::IoError(io_error) => write!(f, "{}", io_error),
-      SegDenseError::Json(serde_json) => write!(f, "{}", serde_json),
-      SegDenseError::JsonMissingRoot => write!(f, "{}", "SegDense JSON: Root Node note found!"),
-      SegDenseError::JsonMissingObject => write!(f, "{}", "SegDense JSON: Object note found!"),
-      SegDenseError::JsonMissingArray => write!(f, "{}", "SegDense JSON: Array Node note found!"),
-      SegDenseError::JsonArraySize => write!(f, "{}", "SegDense JSON: Array size not as expected!"),
-      SegDenseError::JsonMissingInputFeature => write!(f, "{}", "SegDense JSON: Missing input feature!"),
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SegDenseError::IoError(io_error) => write!(f, "{}", io_error),
+            SegDenseError::Json(serde_json) => write!(f, "{}", serde_json),
+            SegDenseError::JsonMissingRoot => {
+                write!(f, "{}", "SegDense JSON: Root Node note found!")
+            }
+            SegDenseError::JsonMissingObject => {
+                write!(f, "{}", "SegDense JSON: Object note found!")
+            }
+            SegDenseError::JsonMissingArray => {
+                write!(f, "{}", "SegDense JSON: Array Node note found!")
+            }
+            SegDenseError::JsonArraySize => {
+                write!(f, "{}", "SegDense JSON: Array size not as expected!")
+            }
+            SegDenseError::JsonMissingInputFeature => {
+                write!(f, "{}", "SegDense JSON: Missing input feature!")
+            }
+        }
     }
-  }
 }
 
 impl std::error::Error for SegDenseError {}
 
 impl From<std::io::Error> for SegDenseError {
-  fn from(err: std::io::Error) -> Self {
-    SegDenseError::IoError(err)
-  }
+    fn from(err: std::io::Error) -> Self {
+        SegDenseError::IoError(err)
+    }
 }
 
 impl From<serde_json::Error> for SegDenseError {
-  fn from(err: serde_json::Error) -> Self {
-    SegDenseError::Json(err)
-  }
+    fn from(err: serde_json::Error) -> Self {
+        SegDenseError::Json(err)
+    }
 }

--- a/navi/segdense/src/error.rs
+++ b/navi/segdense/src/error.rs
@@ -17,8 +17,8 @@ pub enum SegDenseError {
 impl Display for SegDenseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SegDenseError::IoError(io_error) => write!(f, "{}", io_error),
-            SegDenseError::Json(serde_json) => write!(f, "{}", serde_json),
+            SegDenseError::IoError(io_error) => write!(f, "{io_error}"),
+            SegDenseError::Json(serde_json) => write!(f, "{serde_json}"),
             SegDenseError::JsonMissingRoot => {
                 write!(f, "SegDense JSON: Root Node note found!")
             }

--- a/navi/segdense/src/error.rs
+++ b/navi/segdense/src/error.rs
@@ -20,19 +20,19 @@ impl Display for SegDenseError {
             SegDenseError::IoError(io_error) => write!(f, "{}", io_error),
             SegDenseError::Json(serde_json) => write!(f, "{}", serde_json),
             SegDenseError::JsonMissingRoot => {
-                write!(f, "{}", "SegDense JSON: Root Node note found!")
+                write!(f, "SegDense JSON: Root Node note found!")
             }
             SegDenseError::JsonMissingObject => {
-                write!(f, "{}", "SegDense JSON: Object note found!")
+                write!(f, "SegDense JSON: Object note found!")
             }
             SegDenseError::JsonMissingArray => {
-                write!(f, "{}", "SegDense JSON: Array Node note found!")
+                write!(f, "SegDense JSON: Array Node note found!")
             }
             SegDenseError::JsonArraySize => {
-                write!(f, "{}", "SegDense JSON: Array size not as expected!")
+                write!(f, "SegDense JSON: Array size not as expected!")
             }
             SegDenseError::JsonMissingInputFeature => {
-                write!(f, "{}", "SegDense JSON: Missing input feature!")
+                write!(f, "SegDense JSON: Missing input feature!")
             }
         }
     }

--- a/navi/segdense/src/lib.rs
+++ b/navi/segdense/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod error;
-pub mod segdense_transform_spec_home_recap_2022; 
 pub mod mapper;
+pub mod segdense_transform_spec_home_recap_2022;
 pub mod util;

--- a/navi/segdense/src/main.rs
+++ b/navi/segdense/src/main.rs
@@ -5,19 +5,18 @@ use segdense::error::SegDenseError;
 use segdense::util;
 
 fn main() -> Result<(), SegDenseError> {
-  env_logger::init();
-  let args: Vec<String> = env::args().collect();
-  
-  let schema_file_name: &str = if args.len() == 1 {
-    "json/compact.json"
-  } else {
-    &args[1]
-  };
+    env_logger::init();
+    let args: Vec<String> = env::args().collect();
 
-  let json_str = fs::read_to_string(schema_file_name)?;
+    let schema_file_name: &str = if args.len() == 1 {
+        "json/compact.json"
+    } else {
+        &args[1]
+    };
 
-  util::safe_load_config(&json_str)?;
+    let json_str = fs::read_to_string(schema_file_name)?;
 
-  Ok(())
+    util::safe_load_config(&json_str)?;
+
+    Ok(())
 }
-

--- a/navi/segdense/src/mapper.rs
+++ b/navi/segdense/src/mapper.rs
@@ -19,13 +19,13 @@ pub struct FeatureMapper {
 impl FeatureMapper {
     pub fn new() -> FeatureMapper {
         FeatureMapper {
-            map: HashMap::new()
+            map: HashMap::new(),
         }
     }
 }
 
 pub trait MapWriter {
-    fn set(&mut self, feature_id: i64, info: FeatureInfo); 
+    fn set(&mut self, feature_id: i64, info: FeatureInfo);
 }
 
 pub trait MapReader {

--- a/navi/segdense/src/segdense_transform_spec_home_recap_2022.rs
+++ b/navi/segdense/src/segdense_transform_spec_home_recap_2022.rs
@@ -164,7 +164,6 @@ pub struct ComplexFeatureTypeTransformSpec {
     pub tensor_shape: Vec<i64>,
 }
 
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InputFeatureMapRecord {

--- a/navi/segdense/src/util.rs
+++ b/navi/segdense/src/util.rs
@@ -1,17 +1,17 @@
+use log::debug;
 use std::fs;
-use log::{debug};
 
-use serde_json::{Value, Map};
+use serde_json::{Map, Value};
 
 use crate::error::SegDenseError;
-use crate::mapper::{FeatureMapper, FeatureInfo, MapWriter};
+use crate::mapper::{FeatureInfo, FeatureMapper, MapWriter};
 use crate::segdense_transform_spec_home_recap_2022::{self as seg_dense, InputFeature};
 
 pub fn load_config(file_name: &str) -> seg_dense::Root {
-    let json_str = fs::read_to_string(file_name).expect(
-        &format!("Unable to load segdense file {}", file_name));
-    let seg_dense_config = parse(&json_str).expect(
-        &format!("Unable to parse segdense file {}", file_name));
+    let json_str = fs::read_to_string(file_name)
+        .expect(&format!("Unable to load segdense file {}", file_name));
+    let seg_dense_config =
+        parse(&json_str).expect(&format!("Unable to parse segdense file {}", file_name));
     return seg_dense_config;
 }
 
@@ -45,14 +45,12 @@ pub fn safe_load_config(json_str: &str) -> Result<FeatureMapper, SegDenseError> 
 }
 
 pub fn load_from_parsed_config_ref(root: &seg_dense::Root) -> FeatureMapper {
-    load_from_parsed_config(root.clone()).unwrap_or_else(
-      |error| panic!("Error loading all_config.json - {}", error))
+    load_from_parsed_config(root.clone())
+        .unwrap_or_else(|error| panic!("Error loading all_config.json - {}", error))
 }
 
 // Perf note : make 'root' un-owned
-pub fn load_from_parsed_config(root: seg_dense::Root) ->
-    Result<FeatureMapper, SegDenseError> {
-
+pub fn load_from_parsed_config(root: seg_dense::Root) -> Result<FeatureMapper, SegDenseError> {
     let v = root.input_features_map;
 
     // Do error check
@@ -86,7 +84,7 @@ pub fn load_from_parsed_config(root: seg_dense::Root) ->
             Some(info) => {
                 debug!("{:?}", info);
                 fm.set(feature_id, info)
-            },
+            }
             None => (),
         }
     }
@@ -94,19 +92,22 @@ pub fn load_from_parsed_config(root: seg_dense::Root) ->
     Ok(fm)
 }
 #[allow(dead_code)]
-fn add_feature_info_to_mapper(feature_mapper: &mut FeatureMapper, input_features: &Vec<InputFeature>) {
+fn add_feature_info_to_mapper(
+    feature_mapper: &mut FeatureMapper,
+    input_features: &Vec<InputFeature>,
+) {
     for input_feature in input_features.iter() {
-            let feature_id = input_feature.feature_id;
-            let feature_info = to_feature_info(input_feature);
-    
-            match feature_info {
-                Some(info) => {
-                    debug!("{:?}", info);
-                    feature_mapper.set(feature_id, info)
-                },
-                None => (),
+        let feature_id = input_feature.feature_id;
+        let feature_info = to_feature_info(input_feature);
+
+        match feature_info {
+            Some(info) => {
+                debug!("{:?}", info);
+                feature_mapper.set(feature_id, info)
             }
+            None => (),
         }
+    }
 }
 
 pub fn to_feature_info(input_feature: &seg_dense::InputFeature) -> Option<FeatureInfo> {
@@ -139,7 +140,7 @@ pub fn to_feature_info(input_feature: &seg_dense::InputFeature) -> Option<Featur
             2 => 0,
             3 => 2,
             _ => -1,
-        }
+        },
     };
 
     if input_feature.index < 0 {
@@ -156,4 +157,3 @@ pub fn to_feature_info(input_feature: &seg_dense::InputFeature) -> Option<Featur
         index_within_tensor: input_feature.index,
     })
 }
-

--- a/navi/segdense/src/util.rs
+++ b/navi/segdense/src/util.rs
@@ -44,7 +44,7 @@ pub fn safe_load_config(json_str: &str) -> Result<FeatureMapper, SegDenseError> 
 
 pub fn load_from_parsed_config_ref(root: &seg_dense::Root) -> FeatureMapper {
     load_from_parsed_config(root)
-        .unwrap_or_else(|error| panic!("Error loading all_config.json - {}", error))
+        .unwrap_or_else(|error| panic!("Error loading all_config.json - {error}"))
 }
 
 pub fn load_from_parsed_config(root: &seg_dense::Root) -> Result<FeatureMapper, SegDenseError> {

--- a/navi/segdense/src/util.rs
+++ b/navi/segdense/src/util.rs
@@ -9,15 +9,13 @@ use crate::segdense_transform_spec_home_recap_2022::{self as seg_dense, InputFea
 
 pub fn load_config(file_name: &str) -> seg_dense::Root {
     let json_str = fs::read_to_string(file_name)
-        .expect(&format!("Unable to load segdense file {}", file_name));
-    let seg_dense_config =
-        parse(&json_str).expect(&format!("Unable to parse segdense file {}", file_name));
-    return seg_dense_config;
+        .unwrap_or_else(|_| panic!("Unable to load segdense file {file_name}"));
+    parse(&json_str).unwrap_or_else(|_| panic!("Unable to parse segdense file {file_name}"))
 }
 
 pub fn parse(json_str: &str) -> Result<seg_dense::Root, SegDenseError> {
     let root: seg_dense::Root = serde_json::from_str(json_str)?;
-    return Ok(root);
+    Ok(root)
 }
 
 /**
@@ -80,12 +78,9 @@ pub fn load_from_parsed_config(root: seg_dense::Root) -> Result<FeatureMapper, S
         let feature_id = input_feature.feature_id;
         let feature_info = to_feature_info(&input_feature);
 
-        match feature_info {
-            Some(info) => {
-                debug!("{:?}", info);
-                fm.set(feature_id, info)
-            }
-            None => (),
+        if let Some(info) = feature_info {
+            debug!("{info:?}");
+            fm.set(feature_id, info)
         }
     }
 
@@ -94,18 +89,15 @@ pub fn load_from_parsed_config(root: seg_dense::Root) -> Result<FeatureMapper, S
 #[allow(dead_code)]
 fn add_feature_info_to_mapper(
     feature_mapper: &mut FeatureMapper,
-    input_features: &Vec<InputFeature>,
+    input_features: &[InputFeature],
 ) {
     for input_feature in input_features.iter() {
         let feature_id = input_feature.feature_id;
         let feature_info = to_feature_info(input_feature);
 
-        match feature_info {
-            Some(info) => {
-                debug!("{:?}", info);
-                feature_mapper.set(feature_id, info)
-            }
-            None => (),
+        if let Some(info) = feature_info {
+            debug!("{info:?}");
+            feature_mapper.set(feature_id, info)
         }
     }
 }


### PR DESCRIPTION
### Refactors
* Avoid cloning `seg_dense::Root` [here](https://github.com/twitter/the-algorithm/blob/main/navi/segdense/src/util.rs#L68).
* [Clippy](https://doc.rust-lang.org/clippy/) issues.
* Macros parameters.
* Update style.

