### PR TITLE
prefer fold over map followed by getOrElse

### DIFF
--- a/visibilitylib/src/main/scala/com/twitter/visibility/rules/ExperimentBase.scala
+++ b/visibilitylib/src/main/scala/com/twitter/visibility/rules/ExperimentBase.scala
@@ -7,12 +7,7 @@ import com.twitter.visibility.models.LabelSource
 object ExperimentBase {
   val sourceToParamMap: Map[LabelSource, LabelSourceParam] = Map.empty
 
-  final def shouldFilterForSource(params: Params, labelSourceOpt: Option[LabelSource]): Boolean = {
+  final def shouldFilterForSource(params: Params, labelSourceOpt: Option[LabelSource]): Boolean =
     labelSourceOpt
-      .map { source =>
-        val param = ExperimentBase.sourceToParamMap.get(source)
-        param.map(params.apply).getOrElse(true)
-      }
-      .getOrElse(true)
-  }
+      .fold(true)(source => ExperimentBase.sourceToParamMap.get(source).fold(true)(params.apply))
 }


### PR DESCRIPTION
`fold` combinator is a shorthand way of encoding `map` + `getOrElse` pattern.