### PR TITLE
Update validator.rs

### DIFF
--- a/navi/navi/src/cores/validator.rs
+++ b/navi/navi/src/cores/validator.rs
@@ -1,4 +1,4 @@
-pub mod validatior {
+pub mod validator {
     pub mod cli_validator {
         use crate::cli_args::{ARGS, MODEL_SPECS};
 
@@ -11,12 +11,12 @@ pub mod validatior {
         }
 
         pub fn validate_ps_model_args() {
-            assert!(ARGS.versions_per_model <= 2);
             assert!(ARGS.versions_per_model >= 1);
+            assert!(ARGS.versions_per_model <= 2);
             assert_eq!(MODEL_SPECS.len(), ARGS.input.len());
             assert_eq!(MODEL_SPECS.len(), ARGS.model_dir.len());
             assert_eq!(MODEL_SPECS.len(), ARGS.max_batch_size.len());
-            assert_eq!(MODEL_SPECS.len(), ARGS.batch_time_out_millis.len());
+            assert_eq!(MODEL_SPECS.len(), ARGS.batch_timeout_millis.len());
         }
     }
 }


### PR DESCRIPTION
I figured the 'cli_args' module wasn't defined. And the 'OUTPUTS' too. Might be intentional though.  However, in the 'validate_ps_model_args' it is obvious the order of the 'assert!' is not correct.