### PR TITLE
Make an optimization for BatchingClient

### DIFF
--- a/src/java/com/twitter/search/ingester/pipeline/twitter/RetrieveCardBatchedStage.java
+++ b/src/java/com/twitter/search/ingester/pipeline/twitter/RetrieveCardBatchedStage.java
@@ -134,7 +134,7 @@ public class RetrieveCardBatchedStage extends TwitterBaseStage
         }));
   }
 
-  private Future<Map<Long, Card2>> batchRetrieveURLs(Set<Long> keys) {
+  private Future<Map<Long, Card2>> batchRetrieveURLs(List<Long> keys) {
     retrieveCardsTimer.start();
     totalTweets.increment(keys.size());
 
@@ -145,7 +145,7 @@ public class RetrieveCardBatchedStage extends TwitterBaseStage
 
     GetTweetsRequest request = new GetTweetsRequest()
         .setOptions(options)
-        .setTweet_ids(new ArrayList<>(keys));
+        .setTweet_ids(keys);
 
     return tweetyPieService.get_tweets(request)
         .onFailure(throwable -> {

--- a/src/java/com/twitter/search/ingester/pipeline/util/ResponseNotReturnedException.java
+++ b/src/java/com/twitter/search/ingester/pipeline/util/ResponseNotReturnedException.java
@@ -2,6 +2,6 @@ package com.twitter.search.ingester.pipeline.util;
 
 public class ResponseNotReturnedException extends Exception {
   ResponseNotReturnedException(Object request) {
-    super("Response not returned in batch for request: " + request);
+    super("Response not returned in batch for request: " + request, null, false, false);
   }
 }


### PR DESCRIPTION
This optimization avoids allocation of new hash table on each batch being sent by using an array storing original content of requests to send. Not sure how often this code path is taken, but based off of the comment left originally, I decided to make this.
Not sure whether this is possible since I don't know which type `GetTweetsRequest#setTweet_ids` accepts as the parameter and how its fields are serialized (I assume its parameter is a plain `List`, not an `ArrayList` specifically).