### PR TITLE
Fix 10k favs check

### DIFF
--- a/home-mixer/server/src/main/scala/com/twitter/home_mixer/functional_component/decorator/HomeTweetTypePredicates.scala
+++ b/home-mixer/server/src/main/scala/com/twitter/home_mixer/functional_component/decorator/HomeTweetTypePredicates.scala
@@ -160,7 +160,7 @@ object HomeTweetTypePredicates {
     ("has_gte_1k_favs", _.getOrElse(EarlybirdFeature, None).exists(_.favCountV2.exists(_ >= 1000))),
     (
       "has_gte_10k_favs",
-      _.getOrElse(EarlybirdFeature, None).exists(_.favCountV2.exists(_ >= 1000))),
+      _.getOrElse(EarlybirdFeature, None).exists(_.favCountV2.exists(_ >= 10000))),
     (
       "has_gte_100k_favs",
       _.getOrElse(EarlybirdFeature, None).exists(_.favCountV2.exists(_ >= 100000))),


### PR DESCRIPTION
It originally was check if it was greater than or equal to 1000. This commit would fix the issue by replacing 1000 with the correct number, 10000.