### PR TITLE
Improve clarity for comments

### DIFF
--- a/src/java/com/twitter/search/earlybird/search/AbstractResultsCollector.java
+++ b/src/java/com/twitter/search/earlybird/search/AbstractResultsCollector.java
@@ -622,8 +622,9 @@ public abstract class AbstractResultsCollector<R extends SearchRequestInfo,
     return requestDebugMode >= 5;
   }
 
-  // Use this for per-result debug info. Useful for queries with no results
-  // or a very small number of results.
+  // Use this for per-result debug info.
+  // Useful for queries with no results or a very small number of results.
+  // A value of 6 or higher indicates that verbose debug information should be collected.
   protected boolean shouldCollectVerboseDebugInfo() {
     return requestDebugMode >= 6;
   }

--- a/src/java/com/twitter/search/earlybird/search/AntiGamingFilter.java
+++ b/src/java/com/twitter/search/earlybird/search/AntiGamingFilter.java
@@ -157,7 +157,7 @@ public class AntiGamingFilter {
     fromUserIDs =
         reader.getNumericDocValues(EarlybirdFieldConstant.FROM_USER_ID_CSF.getFieldName());
 
-    // fill the id whitelist for the current segment.  initialize lazily.
+    // fill the id whitelist for the current segment. initialize lazily.
     segmentUserIDWhitelist = null;
 
     SortedSet<Integer> sortedFromUserDocIds = new TreeSet<>();


### PR DESCRIPTION
Improve clarity and documentation for the shouldCollectVerboseDebugInfo() method.
The comments clarify that a value of 6 or higher indicates that verbose debug information should be collected.