### PR TITLE
Change algorithm

### DIFF
--- a/src/java/com/twitter/search/core/earlybird/index/util/SearchSortUtils.java
+++ b/src/java/com/twitter/search/core/earlybird/index/util/SearchSortUtils.java
@@ -21,7 +21,7 @@ public abstract class SearchSortUtils {
     int high = end;
     Preconditions.checkState(comparator.compare(low, key) <= comparator.compare(high, key));
     while (low <= high) {
-      int mid = (low + high) >>> 1;
+      int mid = (low & high) + ((low ^ high) >>> 1);
       int result = comparator.compare(mid, key);
       if (result < 0) {
         low = mid + 1;


### PR DESCRIPTION
There is no difference in efficiency to prevent overflow when adding low and high. 
You can avoid using this method to convert long sum=(long) low+high in the future; 
If this tool class needs to perform a larger range of calculations in the future ^_^