### PR TITLE
Limit penalization on blocks / mutes for a cooldown of 180 days. Fix #658

### DIFF
--- a/src/scala/com/twitter/interaction_graph/scio/agg_negative/InteractionGraphNegativeJob.scala
+++ b/src/scala/com/twitter/interaction_graph/scio/agg_negative/InteractionGraphNegativeJob.scala
@@ -49,17 +49,30 @@ object InteractionGraphNegativeJob extends ScioBeamJob[InteractionGraphNegativeO
     val endTs = opts.interval.getEndMillis
 
     // read input datasets
+
+    // We only count blocks in the past 180 days to make sure we don't fall
+    // into any long-term cancellation effects in a tweeter.
+    // As an example, some accounts may have higher count of blocks because
+    // what they said is controversial in one period of time but it might be
+    // not in other (for example, @RWMaloneMD or others)
     val blocks: SCollection[InteractionGraphRawInput] =
       GraphUtil.getFlockFeatures(
         readSnapshot(FlockBlocksEdgesScalaDataset, sc),
         FeatureName.NumBlocks,
         endTs)
+      .filter(_.age < 180)
 
+    // We only count mutes in the past 180 days to make sure we don't fall
+    // into any long-term cancellation effects in a tweeter.
+    // As an example, some accounts may have higher count of blocks because
+    // what they said is controversial in one period of time but it might be
+    // not in other (for example, @RWMaloneMD or others)
     val mutes: SCollection[InteractionGraphRawInput] =
       GraphUtil.getFlockFeatures(
         readSnapshot(FlockMutesEdgesScalaDataset, sc),
         FeatureName.NumMutes,
         endTs)
+      .filter(_.age < 180)
 
     val abuseReports: SCollection[InteractionGraphRawInput] =
       GraphUtil.getFlockFeatures(


### PR DESCRIPTION
Currently, is reported that blocks and mutes are excessively penalized (see #658).

I myself experimented the side effects from cancellation efforts from a woke majority and saw how engagement decreased significantly after that happened.
By setting a window limit on blocks and mutes we still take those blocks in consideration, but only during a cooldown period (180 days), so the account is not permanently cancelled.

This PR fixes it by setting a cooldown of 180 days for blocks and mutes