### PR TITLE
perf: Add error handling to load_data method

### DIFF
--- a/trust_and_safety_models/toxicity/data/dataframe_loader.py
+++ b/trust_and_safety_models/toxicity/data/dataframe_loader.py
@@ -93,11 +93,19 @@ class ENLoader(DataframeLoader):
 
     return df
 
-  def load_data(self, test=False, **kwargs):
-    if "reload" in kwargs and kwargs["reload"]:
-      df = self._reload(test, kwargs["reload"])
-      if df is not None and df.shape[0] > 0:
-        return df
+  def load_data(self, test=False, reload_data=False):
+    data = None
+    if reload_data:
+        try:
+            data = self._reload(test, reload_data)
+        except Exception as e:
+            print(f"An error occurred while reloading the data: {str(e)}")
+            return None
+    if data is not None and data.shape[0] > 0:
+        return data
+    else:
+        print("The reloaded data is empty or None")
+        return None
 
     df = None
     query_settings = self.query_settings


### PR DESCRIPTION
This commit adds error handling to the load_data method to catch any exceptions raised by the _reload method. If an exception is caught, the method will print an error message and return None. If the _reload method returns a non-empty DataFrame, the method will return the data. If the data is empty or None, the method will print a message and return None. Additionally, the reload argument has been renamed to reload_data for clarity.