### PR TITLE
small typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ These are the main components of the Recommendation Algorithm included in this r
 | Tweet mixing & filtering | [home-mixer](home-mixer/README.md) | Main service used to construct and serve the Home Timeline. Built on [product-mixer](product-mixer/README.md) |
 |                          | [visibility-filters](visibilitylib/README.md) | Responsible for filtering Twitter content to support legal compliance, improve product quality, increase user trust, protect revenue through the use of hard-filtering, visible product treatments, and coarse-grained downranking. |
 |                          | [timelineranker](timelineranker/README.md) | Legacy service which provides relevance-scored tweets from the Earlybird Search Index and UTEG service. |
-| Software framework | [navi](navi/navi/README.md) | High performance, machine learning model serving written in Rust. |
+| Software framework | [navi](navi/navi/README.md) | High performance machine learning model serving server written in Rust. |
 |                    | [product-mixer](product-mixer/README.md) | Software framework for building feeds of content. |
 |                    | [twml](twml/README.md) | Legacy machine learning framework built on TensorFlow v1. |
 

--- a/src/java/com/twitter/search/README.md
+++ b/src/java/com/twitter/search/README.md
@@ -14,7 +14,7 @@ At Twitter, we use Tweet Search System (Earlybird) to do Home Timeline In-networ
 ## High-level architecture
 We split our entire tweet search index into three clusters: a **realtime** cluster indexing all public tweets posted in about the last 7 days, a **protected** cluster indexing all protected tweets for the same timeframe; and an **archive** cluster indexing all tweets ever posted, up to about two days ago. 
 
-Earlybird addresses the challenges of scaling real-time search by splitting each cluster across multiple **partitions**, each responsible for a portion of the index. The architecture uses a distributed *inverted index* that is sharded and replicated. This design allows for efficient index updates and query processing. 
+Earlybird addresses the challenges of scaling real-time search by splitting each cluster across multiple **partitions**, each responsible for a portion of the index. The architecture uses a distributed [*inverted index*](https://en.wikipedia.org/wiki/Inverted_index) that is sharded and replicated. This design allows for efficient index updates and query processing. 
 
 The system also employs an incremental indexing approach, enabling it to process and index new tweets in real-time as they arrive. With single writer, multiple reader structure, Earlybird can handle a large number of real-time updates and queries concurrently while maintaining low query latency. The system can achieve high query throughput and low query latency while maintaining a high degree of index freshness. 
 


### PR DESCRIPTION
instead of `High performance, machine learning model serving written in Rust` -> `High performance machine learning model serving server written in Rust`,
deleted `,`
added `server`
added wikipedia link for `inverted index`