### PR TITLE
Why should russia's illegal invasion of ukraine be singled out in SpaceSafety?

### DIFF
--- a/visibilitylib/src/main/scala/com/twitter/visibility/models/SpaceSafetyLabelType.scala
+++ b/visibilitylib/src/main/scala/com/twitter/visibility/models/SpaceSafetyLabelType.scala
@@ -36,7 +36,6 @@ object SpaceSafetyLabelType extends SafetyLabelType {
     s.SpaceSafetyLabelType.HatefulHighRecall -> HatefulHighRecall,
     s.SpaceSafetyLabelType.ViolenceHighRecall -> ViolenceHighRecall,
     s.SpaceSafetyLabelType.HighToxicityModelScore -> HighToxicityModelScore,
-    s.SpaceSafetyLabelType.UkraineCrisisTopic -> UkraineCrisisTopic,
     s.SpaceSafetyLabelType.DoNotPublicPublish -> DoNotPublicPublish,
     s.SpaceSafetyLabelType.Reserved16 -> Deprecated,
     s.SpaceSafetyLabelType.Reserved17 -> Deprecated,
@@ -68,8 +67,6 @@ object SpaceSafetyLabelType extends SafetyLabelType {
   case object HatefulHighRecall extends SpaceSafetyLabelType
   case object ViolenceHighRecall extends SpaceSafetyLabelType
   case object HighToxicityModelScore extends SpaceSafetyLabelType
-
-  case object UkraineCrisisTopic extends SpaceSafetyLabelType
 
   case object DoNotPublicPublish extends SpaceSafetyLabelType
 


### PR DESCRIPTION
Shouldn't some more generic topic(s) be created if need be? Are the existing categories not sufficient to capture problematic content? This topic seems not to be generic enough - if this topic is singled out, then why not others? Where does the line get drawn. I think this needs to be rethought a little.

(Appreciate the bravery of open sourcing the algorithm for inspection. Kudos for this.)