### PR TITLE
article "THE" added

### DIFF
--- a/src/python/twitter/deepbird/projects/timelines/scripts/models/earlybird/README.md
+++ b/src/python/twitter/deepbird/projects/timelines/scripts/models/earlybird/README.md
@@ -1,14 +1,14 @@
 # Earlybird Light Ranker
 
-*Note: the light ranker is an old part of the stack which we are currently in the process of replacing.
+_Note: the light ranker is an old part of the stack which we are currently in the process of replacing.
 The current model was last trained several years ago, and uses some very strange features.
-We are working on training a new model, and eventually rebuilding this part of the stack entirely.*
+We are working on training a new model, and eventually rebuilding this part of the stack entirely._
 
 The Earlybird light ranker is a logistic regression model which predicts the likelihood that the user will engage with a
 tweet.
 It is intended to be a simplified version of the heavy ranker which can run on a greater amount of tweets.
 
-There are currently 2 main light ranker models in use: one for ranking in network tweets (`recap_earlybird`), and
+There are currently two main light ranker models in use: one for ranking in network tweets (`recap_earlybird`), and
 another for
 out of network (UTEG) tweets (`rectweet_earlybird`). Both models are trained using the `train.py` script which is
 included in this directory. They differ mainly in the set of features

--- a/timelineranker/README.md
+++ b/timelineranker/README.md
@@ -1,8 +1,6 @@
-Overview
-========
+# Overview
 
 **TimelineRanker** (TLR) is a legacy service which provides relevance-scored tweets from the Earlybird Search Index and User Tweet Entity Graph (UTEG) service. Despite its name, it no longer does any kind of heavy ranking/model based ranking itself - just uses relevance scores from the Search Index for ranked tweet endpoints.
-
 
 The following is a list of major services that Timeline Ranker interacts with:
 
@@ -16,7 +14,7 @@ Timeline Ranker calls UTEG to fetch a list of tweets liked by the users you foll
 
 **Socialgraph**
 
-Timeline Ranker calls Social Graph Service to obtain follow graph and user states such as blocked, muted, retweets muted, etc.
+Timeline Ranker calls the Social Graph Service to obtain follow graph and user states such as blocked, muted, retweets muted, etc.
 
 **TweetyPie**
 
@@ -31,6 +29,3 @@ Timeline Ranker hydrates some tweet features (eg, user languages) from Manhattan
 Home Mixer calls Timeline Ranker to fetch tweets from the Earlybird Search Index and User Tweet Entity Graph (UTEG) service to power both the For You and Following Home Timelines.
 
 Timeline Ranker does light ranking based on Earlybird tweet candidate scores and truncates to the number of candidates requested by Home Mixer based on these scores
-
-
-


### PR DESCRIPTION
The name "Social Graph Service" refers to a service that provides access to the social graph, which is a representation of the connections between users in a social network.