### PR TITLE
Simple earlybird typos

### DIFF
--- a/src/java/com/twitter/search/common/schema/earlybird/EarlybirdSchemaBuilder.java
+++ b/src/java/com/twitter/search/common/schema/earlybird/EarlybirdSchemaBuilder.java
@@ -27,7 +27,7 @@ public class EarlybirdSchemaBuilder extends SchemaBuilder {
 
   /**
    * Configure the specified field to be Out-of-order.
-   * In the realtime cluster, this causes Earlybird to used the skip list posting format.
+   * In the realtime cluster, this causes Earlybird to use the skip list posting format.
    */
   public final EarlybirdSchemaBuilder withOutOfOrderEnabledForField(String fieldName) {
     if (!shouldIncludeField(fieldName)) {

--- a/src/java/com/twitter/search/common/schema/earlybird/EarlybirdThriftDocumentBuilder.java
+++ b/src/java/com/twitter/search/common/schema/earlybird/EarlybirdThriftDocumentBuilder.java
@@ -320,7 +320,7 @@ public final class EarlybirdThriftDocumentBuilder extends ThriftDocumentBuilder 
   }
 
   /**
-   * Add a list of places. The place are U64 encoded place IDs.
+   * Add a list of places. The places are U64 encoded place IDs.
    */
   public EarlybirdThriftDocumentBuilder withPlacesField(List<String> places) {
     if (isNotEmpty(places)) {
@@ -509,7 +509,7 @@ public final class EarlybirdThriftDocumentBuilder extends ThriftDocumentBuilder 
   }
 
   /**
-   * Add escherbird annotation fields.
+   * Add earlybird annotation fields.
    */
   public EarlybirdThriftDocumentBuilder withAnnotationEntities(List<String> entities) {
     if (isNotEmpty(entities)) {


### PR DESCRIPTION
I'm not sure if `escherbird ` was intentional but I couldn't find anything relating to it in the document, so assumed the intended word was `easrlybird`