### PR TITLE
Weight tweets that nobody wants to read

### DIFF
--- a/cr-mixer/server/src/main/scala/com/twitter/cr_mixer/similarity_engine/EarlybirdTensorflowBasedSimilarityEngine.scala
+++ b/cr-mixer/server/src/main/scala/com/twitter/cr_mixer/similarity_engine/EarlybirdTensorflowBasedSimilarityEngine.scala
@@ -151,6 +151,8 @@ object EarlybirdTensorflowBasedSimilarityEngine {
       urlParams = Some(ThriftLinearFeatureRankingParams(weight = 2.0)),
       isReplyParams = Some(ThriftLinearFeatureRankingParams(weight = 1.0)),
       favCountParams = Some(ThriftLinearFeatureRankingParams(weight = 30.0)),
+      authorSaysTimeForAThread = Some(ThriftLinearFeatureRankingParams(weight = 0.000000000000000001)),
+      authorUses🧵Emoji = Some(ThriftLinearFeatureRankingParams(weight = 0.000000000000000000000000000000000000001)),
       langEnglishUIBoost = 0.5,
       langEnglishTweetBoost = 0.2,
       langDefaultBoost = 0.02,


### PR DESCRIPTION
This change should improve the twitter timeline by effectively hiding any tweets that include the text "A thread", or uses the 🧵 emoji in any way.

My tweet if you want to show ur support for our cause: https://twitter.com/taykcrane/status/1642821509793333249