### PR TITLE
Variable name typo Corrections 

### DIFF
--- a/ann/src/main/java/com/twitter/ann/hnsw/DistancedItemQueue.java
+++ b/ann/src/main/java/com/twitter/ann/hnsw/DistancedItemQueue.java
@@ -68,7 +68,6 @@ public class DistancedItemQueue<U, T> implements Iterable<DistancedItem<T>> {
 
   /**
    * Return if queue is non empty or not
-   *
    * @return true if queue is not empty else false
    */
   public boolean nonEmpty() {
@@ -77,7 +76,6 @@ public class DistancedItemQueue<U, T> implements Iterable<DistancedItem<T>> {
 
   /**
    * Return root of the queue
-   *
    * @return root of the queue i.e min/max element depending upon min-max queue
    */
   public DistancedItem<T> peek() {
@@ -86,7 +84,6 @@ public class DistancedItemQueue<U, T> implements Iterable<DistancedItem<T>> {
 
   /**
    * Dequeue root of the queue.
-   *
    * @return remove and return root of the queue i.e min/max element depending upon min-max queue
    */
   public DistancedItem<T> dequeue() {
@@ -95,7 +92,6 @@ public class DistancedItemQueue<U, T> implements Iterable<DistancedItem<T>> {
 
   /**
    * Dequeue all the elements from queueu with ordering mantained
-   *
    * @return remove all the elements in the order of the queue i.e min/max queue.
    */
   public List<DistancedItem<T>> dequeueAll() {
@@ -109,7 +105,6 @@ public class DistancedItemQueue<U, T> implements Iterable<DistancedItem<T>> {
 
   /**
    * Convert queue to list
-   *
    * @return list of elements of queue with distance and without any specific ordering
    */
   public List<DistancedItem<T>> toList() {
@@ -118,7 +113,6 @@ public class DistancedItemQueue<U, T> implements Iterable<DistancedItem<T>> {
 
   /**
    * Convert queue to list
-   *
    * @return list of elements of queue without any specific ordering
    */
   List<T> toListWithItem() {
@@ -146,7 +140,6 @@ public class DistancedItemQueue<U, T> implements Iterable<DistancedItem<T>> {
 
   /**
    * Size
-   *
    * @return size of the queue
    */
   public int size() {
@@ -155,7 +148,6 @@ public class DistancedItemQueue<U, T> implements Iterable<DistancedItem<T>> {
 
   /**
    * Is Min queue
-   *
    * @return true if min queue else false
    */
   public boolean isMinQueue() {
@@ -164,7 +156,6 @@ public class DistancedItemQueue<U, T> implements Iterable<DistancedItem<T>> {
 
   /**
    * Returns origin (base element) of the queue
-   *
    * @return origin of the queue
    */
   public U getOrigin() {

--- a/ann/src/main/java/com/twitter/ann/hnsw/HnswIndex.java
+++ b/ann/src/main/java/com/twitter/ann/hnsw/HnswIndex.java
@@ -37,7 +37,6 @@ import com.twitter.search.common.file.AbstractFile;
  * Typed multithreaded HNSW implementation supporting creation/querying of approximate nearest neighbour
  * Paper: https://arxiv.org/pdf/1603.09320.pdf
  * Multithreading impl based on NMSLIB version : https://github.com/nmslib/hnsw/blob/master/hnswlib/hnswalg.h
- *
  * @param <T> The type of items inserted / searched in the HNSW index.
  * @param <Q> The type of KNN query.
  */

--- a/ann/src/main/java/com/twitter/ann/hnsw/HnswIndexIOUtil.java
+++ b/ann/src/main/java/com/twitter/ann/hnsw/HnswIndexIOUtil.java
@@ -106,7 +106,6 @@ public final class HnswIndexIOUtil {
 
   /**
    * Save hnsw graph in file
-   *
    * @return number of keys in the graph
    */
   public static <T> int saveHnswGraphEntries(

--- a/ann/src/main/scala/com/twitter/ann/annoy/AnnoyCommon.scala
+++ b/ann/src/main/scala/com/twitter/ann/annoy/AnnoyCommon.scala
@@ -36,7 +36,7 @@ object AnnoyCommon {
 
 case class AnnoyRuntimeParams(
   /* Number of vectors to evaluate while searching. A larger value will give more accurate results, but will take longer time to return.
-   * Default value would be numberOfTrees*numberOfNeigboursRequested
+   * Default value would be numberOfTrees*numberOfNeighboursRequested
    */
   nodesToExplore: Option[Int])
     extends RuntimeParams {

--- a/ann/src/main/scala/com/twitter/ann/annoy/RawAnnoyQueryIndex.scala
+++ b/ann/src/main/scala/com/twitter/ann/annoy/RawAnnoyQueryIndex.scala
@@ -102,9 +102,9 @@ private[this] class RawAnnoyQueryIndex[D <: Distance[D]](
   ): Future[List[NeighborWithDistance[Long, D]]] = {
     futurePool {
       val queryVector = embedding.toArray
-      val neigboursToRequest = neighboursToRequest(numOfNeighbours, runtimeParams)
-      val neigbours = index
-        .getNearestWithDistance(queryVector, neigboursToRequest)
+      val neighboursToRequest = neighboursToRequest(numOfNeighbours, runtimeParams)
+      val neighbours = index
+        .getNearestWithDistance(queryVector, neighboursToRequest)
         .asScala
         .take(numOfNeighbours)
         .map { nn =>
@@ -114,12 +114,12 @@ private[this] class RawAnnoyQueryIndex[D <: Distance[D]](
         }
         .toList
 
-      neigbours
+      neighbours
     }
   }
 
   // Annoy java lib do not expose param for numOfNodesToExplore.
-  // Default number is numOfTrees*numOfNeigbours.
+  // Default number is numOfTrees*numOfNeighbours.
   // Simple hack is to artificially increase the numOfNeighbours to be requested and then just cap it before returning.
   private[this] def neighboursToRequest(
     numOfNeighbours: Int,
@@ -127,11 +127,11 @@ private[this] class RawAnnoyQueryIndex[D <: Distance[D]](
   ): Int = {
     annoyParams.nodesToExplore match {
       case Some(nodesToExplore) => {
-        val neigboursToRequest = nodesToExplore / numOfTrees
-        if (neigboursToRequest < numOfNeighbours)
+        val neighboursToRequest = nodesToExplore / numOfTrees
+        if (neighboursToRequest < numOfNeighbours)
           numOfNeighbours
         else
-          neigboursToRequest
+          neighboursToRequest
       }
       case _ => numOfNeighbours
     }


### PR DESCRIPTION
1. corrected spelling of variables in RawAnnoyQueryIndex.scala.
    -> fixed typos in variable names of the above file.
2. Removed unnecessary new lines.
