### PR TITLE
Renames UkraineCrisisTopic safety label to RussianInvasionOfUkraineTopic

### DIFF
--- a/visibilitylib/src/main/scala/com/twitter/visibility/models/SpaceSafetyLabelType.scala
+++ b/visibilitylib/src/main/scala/com/twitter/visibility/models/SpaceSafetyLabelType.scala
@@ -36,7 +36,7 @@ object SpaceSafetyLabelType extends SafetyLabelType {
     s.SpaceSafetyLabelType.HatefulHighRecall -> HatefulHighRecall,
     s.SpaceSafetyLabelType.ViolenceHighRecall -> ViolenceHighRecall,
     s.SpaceSafetyLabelType.HighToxicityModelScore -> HighToxicityModelScore,
-    s.SpaceSafetyLabelType.UkraineCrisisTopic -> UkraineCrisisTopic,
+    s.SpaceSafetyLabelType.RussianInvasionOfUkraineTopic -> RussianInvasionOfUkraineTopic,
     s.SpaceSafetyLabelType.DoNotPublicPublish -> DoNotPublicPublish,
     s.SpaceSafetyLabelType.Reserved16 -> Deprecated,
     s.SpaceSafetyLabelType.Reserved17 -> Deprecated,
@@ -69,7 +69,7 @@ object SpaceSafetyLabelType extends SafetyLabelType {
   case object ViolenceHighRecall extends SpaceSafetyLabelType
   case object HighToxicityModelScore extends SpaceSafetyLabelType
 
-  case object UkraineCrisisTopic extends SpaceSafetyLabelType
+  case object RussianInvasionOfUkraineTopic extends SpaceSafetyLabelType
 
   case object DoNotPublicPublish extends SpaceSafetyLabelType
 


### PR DESCRIPTION
More context about the renamed safety label and the ongoing discussion about possible removal of it can be tracked in https://github.com/twitter/the-algorithm/pull/1524. Until decision is reached there I suggest to at least name it appropriately.

This safety label refers to the ongoing [Russian invasion of Ukraine](https://en.wikipedia.org/wiki/Russian_invasion_of_Ukraine) and should be named as such. Current naming is vague and easy to misinterpret. `RussianInvasionOfUkraineTopic` is a more accurate name. 