### PR TITLE
Enhancement: Efficiency Improvement for GFS Scala Intersection Calculator

### DIFF
--- a/graph-feature-service/src/main/scala/com/twitter/graph_feature_service/util/IntersectionValueCalculator.scala
+++ b/graph-feature-service/src/main/scala/com/twitter/graph_feature_service/util/IntersectionValueCalculator.scala
@@ -21,16 +21,12 @@ object IntersectionValueCalculator {
     x.remaining() >> 3 // divide 8
   }
 
-  /**
-   *
-   */
   def apply(x: ByteBuffer, y: ByteBuffer, intersectionIdLimit: Int): WorkerIntersectionValue = {
 
     val xSize = computeArraySize(x)
     val ySize = computeArraySize(y)
 
-    val largerArray = if (xSize > ySize) x else y
-    val smallerArray = if (xSize > ySize) y else x
+    val (largerArray, smallerArray) = if (xSize > ySize) (x, y) else (y, x)
 
     if (intersectionIdLimit == 0) {
       val result = computeIntersectionUsingBinarySearchOnLargerByteBuffer(smallerArray, largerArray)


### PR DESCRIPTION
Currently, the `IntersectionValueCalculator.scala` utility performs a redundant comparison to assign the `largerArray`/`smallerArray` variables (which are used for binary-search to identify their intersection). 

This PR suggests to assign both variables simultaneously, to marginally improve computational efficiency.

PS. The associated missing comment is also removed - happy to replace that etc.