### PR TITLE
* [COMMENT] - ShadowBan shoud be used to ban bad users, not to become a tool for online criminal militias silence opponents

### DIFF
--- a/src/scala/com/twitter/interaction_graph/scio/agg_negative/InteractionGraphNegativeJob.scala
+++ b/src/scala/com/twitter/interaction_graph/scio/agg_negative/InteractionGraphNegativeJob.scala
@@ -46,6 +46,20 @@ object InteractionGraphNegativeJob extends ScioBeamJob[InteractionGraphNegativeO
     opts: InteractionGraphNegativeOption
   ): Unit = {
 
+    /*There is clearly a PROBLEM with this aproach: ShadowBan is supposed to ban abusers from the plataform, but with
+    * this code, it can be used by malicious groups and virtual militias to produce a coordinated ATTACK to silence
+    * someone they don't like. There are several reports of this on Twitter, people who defend human rights or
+    * produce anti-racist content are being attacked by Follow -> unfollow or block / mute attacks, producing the
+    * unbalance needed to shadowBan someone.
+    *
+    * This is COMPLETELY AGAINST THE IDEIA OF FREE SPEECH. A group of criminals or virtual militias can now SILENCE
+    * someone they don't like, and this ends up being perceived by the user because it is now possible to see the
+    * view statistics from someone's tweets and replies.
+    *
+    * A lot of people are being unfairly silenced by malicious groups now, because that they have access to this code
+    * and now understands how it works and how to do it.*/
+
+
     val endTs = opts.interval.getEndMillis
 
     // read input datasets


### PR DESCRIPTION
There is clearly a PROBLEM with this approach: ShadowBan is supposed to ban abusers from the platform, but with this code, it can be used by malicious groups and virtual militias to produce a coordinated ATTACK to silence someone they don't like. There are several reports of this on Twitter, people who defend human rights or produce anti-racist content are being attacked by Follow -> unfollow or block / mute attacks, producing the unbalance equation needed to shadowBan someone.

This is COMPLETELY AGAINST THE IDEA OF FREE SPEECH. A group of criminals or virtual militias can now SILENCE someone they don't like, and this ends up being perceived by the user because it is now possible to see the view statistics from someone's tweets and replies.

A lot of people are being unfairly silenced by malicious groups now, because that they have access to this code and now understands how it works and how to do it.