### PR TITLE
Optimize BatchPredictionResponse class for improved performance and readability

### DIFF
--- a/twml/libtwml/src/lib/BatchPredictionResponse.cpp
+++ b/twml/libtwml/src/lib/BatchPredictionResponse.cpp
@@ -37,8 +37,8 @@ BatchPredictionResponse::BatchPredictionResponse(
     std::vector<uint64_t> batch_sizes;
     batch_sizes.reserve(dense_values_.size());
 
-    for (int i = 0; i < dense_values_.size(); i++)
-      batch_sizes.push_back(dense_values_.at(i).getDim(0));
+    for (const auto& value : dense_values_)
+      batch_sizes.emplace_back(value.getDim(0));
 
     if (std::adjacent_find(
           batch_sizes.begin(),
@@ -76,14 +76,17 @@ void BatchPredictionResponse::serializePredictions(twml::ThriftWriter &thrift_wr
   thrift_writer.writeStructFieldHeader(TTYPE_LIST, BPR_PREDICTIONS);
   thrift_writer.writeListHeader(TTYPE_STRUCT, getBatchSize());
 
-  for (int i = 0; i < getBatchSize(); i++) {
+  auto batchSize = getBatchSize();
+  auto predictionSize = getPredictionSize();
+
+  for (int i = 0; i < batchSize; i++) {
     twml::DataRecord record = twml::DataRecord();
 
     if (hasContinuous()) {
       const T *values = values_.getData<T>();
       const int64_t *local_keys = keys_.getData<int64_t>();
-      const T *local_values = values + (i * getPredictionSize());
-      record.addContinuous(local_keys, getPredictionSize(), local_values);
+      const T *local_values = values + (i * predictionSize);
+      record.addContinuous(local_keys, predictionSize, local_values);
     }
 
     if (hasDenseTensors()) {


### PR DESCRIPTION
This pull request contains several optimizations to the `BatchPredictionResponse` class. The modifications aim to improve the performance and readability of the code. Here are the key changes:

1. Used `const auto&` in the range-based for loops. This improves the readability of the code and ensures that no unnecessary copies are made, enhancing performance.
2. Replaced `push_back` with `emplace_back` when constructing the `batch_sizes` vector. This is a slight performance gain as `emplace_back` constructs the object in-place, avoiding an unnecessary copy or move operation.
3. Reduced repeated calls to `getBatchSize()` and `getPredictionSize()` within the loop. These values are now stored in local variables before the loop, which should reduce function call overhead.

These updates maintain the original logic and functionality of the `BatchPredictionResponse` class while providing improvements in performance and readability.

#### This is my initial pull request in this project. I'm currently familiarizing myself with the codebase and look forward to contributing more substantially in the future.
Please review these changes and let me know if there are any concerns or feedback.