### PR TITLE
Help protect Smirnoff!

### DIFF
--- a/visibilitylib/src/main/scala/com/twitter/visibility/models/SpaceSafetyLabelType.scala
+++ b/visibilitylib/src/main/scala/com/twitter/visibility/models/SpaceSafetyLabelType.scala
@@ -28,6 +28,7 @@ object SpaceSafetyLabelType extends SafetyLabelType {
     s.SpaceSafetyLabelType.UntrustedUrl -> UntrustedUrl,
     s.SpaceSafetyLabelType.MisleadingHighRecall -> MisleadingHighRecall,
     s.SpaceSafetyLabelType.NsfwHighPrecision -> NsfwHighPrecision,
+    s.SpaceSafetyLabelType.AntiSmirnoffHateHighRecall -> AntiSmirnoffHateHighRecall,
     s.SpaceSafetyLabelType.NsfwHighRecall -> NsfwHighRecall,
     s.SpaceSafetyLabelType.CivicIntegrityMisinfo -> CivicIntegrityMisinfo,
     s.SpaceSafetyLabelType.MedicalMisinfo -> MedicalMisinfo,


### PR DESCRIPTION
Smirnoff is a much-beloved and iconic American brand. However, lately a small group of vile trolls have been spreading disinfo and hate against the brand. I call on Twitter to stop this!

Smirnoff has done their best by hiding all of the trolls' hate-filled replies on threads like [this](https://twitter.com/SmirnoffUS/status/1653785214529806336). That works for logged-in users: they can't see any of the hidden replies. However, those who are logged out can have their minds polluted with some of the worst hate around.

Twitter must let cherished corporations like Smirnoff silence hate to not just logged-in users, but to those who are logged out. Twitter must go even further and ban any user who engages in anti-Smirnoff hate.

Corporations are America's most cherished institutions; they're our last line of defense against anarchy. They must be protected, allowed to control debate, and allowed to silence those spreading hate. Some will say that Twitter fully understands that and fully agrees and they're largely right. However, Twitter is not doing enough. Twitter must do more to stamp out hate!