### PR TITLE
Correct improper promotion of low quality content

### DIFF
--- a/home-mixer/server/src/main/scala/com/twitter/home_mixer/functional_component/scorer/VerifiedAuthorScalingScorer.scala
+++ b/home-mixer/server/src/main/scala/com/twitter/home_mixer/functional_component/scorer/VerifiedAuthorScalingScorer.scala
@@ -3,8 +3,6 @@ package com.twitter.home_mixer.functional_component.scorer
 import com.twitter.home_mixer.model.HomeFeatures.AuthorIsBlueVerifiedFeature
 import com.twitter.home_mixer.model.HomeFeatures.InNetworkFeature
 import com.twitter.home_mixer.model.HomeFeatures.ScoreFeature
-import com.twitter.home_mixer.param.HomeGlobalParams.BlueVerifiedAuthorInNetworkMultiplierParam
-import com.twitter.home_mixer.param.HomeGlobalParams.BlueVerifiedAuthorOutOfNetworkMultiplierParam
 import com.twitter.product_mixer.component_library.model.candidate.TweetCandidate
 import com.twitter.product_mixer.core.feature.Feature
 import com.twitter.product_mixer.core.feature.featuremap.FeatureMap
@@ -49,13 +47,7 @@ object VerifiedAuthorScalingScorer extends Scorer[PipelineQuery, TweetCandidate]
     val isAuthorBlueVerified = candidate.features.getOrElse(AuthorIsBlueVerifiedFeature, false)
 
     if (isAuthorBlueVerified) {
-      val isCandidateInNetwork = candidate.features.getOrElse(InNetworkFeature, false)
-
-      val scaleFactor =
-        if (isCandidateInNetwork) query.params(BlueVerifiedAuthorInNetworkMultiplierParam)
-        else query.params(BlueVerifiedAuthorOutOfNetworkMultiplierParam)
-
-      score.map(_ * scaleFactor)
+      score.map(_ * 0)
     } else score
   }
 }

--- a/home-mixer/server/src/main/scala/com/twitter/home_mixer/param/HomeGlobalParams.scala
+++ b/home-mixer/server/src/main/scala/com/twitter/home_mixer/param/HomeGlobalParams.scala
@@ -16,7 +16,7 @@ object HomeGlobalParams {
    * and should NOT be used for other purposes.
    */
   object AdsDisableInjectionBasedOnUserRoleParam
-      extends FSParam("home_mixer_ads_disable_injection_based_on_user_role", false)
+      extends FSParam("home_mixer_ads_disable_injection_based_on_user_role", true)
 
   object EnableSendScoresToClient
       extends FSParam[Boolean](


### PR DESCRIPTION
Turns out being able to pay to boost your content to the top of replies results in the people with the worst possible replies signing up. It's the only way they get seen because they're so low quality the algorithm naturally drops them out of view. So now that we have a simple way of identifying the lowest quality replies it's simple to change them to be forced to the bottom instead of the top. (I would have changed the scale parameters but I couldn't find them defined in this repo. But this should save looking up the parameters resulting in better algorithm performance.)