### PR TITLE
InteractionGraphNegativeJob: accountLevelShadowbanMaxTime = 1 (in days)

### DIFF
--- a/src/scala/com/twitter/interaction_graph/scio/agg_negative/InteractionGraphNegativeJob.scala
+++ b/src/scala/com/twitter/interaction_graph/scio/agg_negative/InteractionGraphNegativeJob.scala
@@ -78,6 +78,7 @@ object InteractionGraphNegativeJob extends ScioBeamJob[InteractionGraphNegativeO
         readSnapshot(FlockReportAsSpamEdgesScalaDataset, sc),
         FeatureName.NumReportAsSpams,
         endTs)
+      .filter(_.age < accountLevelShadowbanMaxTime)
 
     // we only keep unfollows in the past X days due to the huge size of this dataset,
     // and to prevent permanent "shadow-banning" in the event of accidental unfollows.


### PR DESCRIPTION
Limits all account level "shadow-banning" caused by blocks/mutes/unfollows to X days (configurable);

InteractionGraphNegativeJob.scala: `accountLevelShadowbanMaxTime = 1 //in days`

Rationale;
Account level censorship based on block/mute feature is easily gamified. Any censorship on this platform should be meticulously defined in the rules and performed at a content level.

See also;
https://github.com/twitter/the-algorithm/issues/1386
https://github.com/twitter/the-algorithm/issues/658 
https://github.com/twitter/the-algorithm/pull/660