### PR TITLE
Fix docs typos in GraphJet service files

### DIFF
--- a/RETREIVAL_SIGNALS.md
+++ b/RETREIVAL_SIGNALS.md
@@ -10,17 +10,17 @@ The candidate sourcing stage within the Twitter Recommendation algorithm serves 
 | Author Unfollow       | The accounts which user recently unfollows.                           |
 | Author Mute           | The accounts which user have muted.                                   |
 | Author Block          | The accounts which user have blocked                                  |
-| Tweet Favorite        | The tweets which user clicked the like botton.                        | 
-| Tweet Unfavorite      | The tweets which user clicked the unlike botton.                      |       
+| Tweet Favorite        | The tweets which user clicked the like button.                        | 
+| Tweet Unfavorite      | The tweets which user clicked the unlike button.                      |             
 | Retweet               | The tweets which user retweeted                                       |
 | Quote Tweet           | The tweets which user retweeted with comments.                        |
 | Tweet Reply           | The tweets which user replied.                                        |
-| Tweet Share           | The tweets which user clicked the share botton.                       |
-| Tweet Bookmark        | The tweets which user clicked the bookmark botton.                    |
+| Tweet Share           | The tweets which user clicked the share button.                       |
+| Tweet Bookmark        | The tweets which user clicked the bookmark button.                    |
 | Tweet Click           | The tweets which user clicked and viewed the tweet detail page.       |
 | Tweet Video Watch     | The video tweets which user watched certain seconds or percentage.    |
-| Tweet Don't like      | The tweets which user clicked "Not interested in this tweet" botton.  |
-| Tweet Report          | The tweets which user clicked "Report Tweet" botton.                  |
+| Tweet Don't like      | The tweets which user clicked "Not interested in this tweet" button.  |
+| Tweet Report          | The tweets which user clicked "Report Tweet" button.                  |
 | Notification Open     | The push notification tweets which user opened.                       |
 | Ntab click            | The tweets which user click on the Notifications page.                |               
 | User AddressBook      | The author accounts identifiers of the user's addressbook.            | 

--- a/src/scala/com/twitter/recos/user_tweet_entity_graph/README.md
+++ b/src/scala/com/twitter/recos/user_tweet_entity_graph/README.md
@@ -1,7 +1,7 @@
 # UserTweetEntityGraph (UTEG)
 
 ## What is it
-User Tweet Entity Graph (UTEG) is a Finalge thrift service built on the GraphJet framework. It maintains a graph of user-tweet relationships and serves user recommendations based on traversals in this graph.
+User Tweet Entity Graph (UTEG) is a Finagle thrift service built on the GraphJet framework. It maintains a graph of user-tweet relationships and serves user recommendations based on traversals in this graph.
 
 ## How is it used on Twitter
 UTEG generates the "XXX Liked" out-of-network tweets seen on Twitter's Home Timeline.

--- a/src/scala/com/twitter/recos/user_tweet_graph/README.md
+++ b/src/scala/com/twitter/recos/user_tweet_graph/README.md
@@ -1,7 +1,7 @@
 # UserTweetGraph (UTG)
 
 ## What is it
-User Tweet Graph (UTG) is a Finalge thrift service built on the GraphJet framework. In maintains a graph of user-tweet engagements and serves user recommendations based on traversals of this graph.
+User Tweet Graph (UTG) is a Finagle thrift service built on the GraphJet framework. It maintains a graph of user-tweet engagements and serves user recommendations based on traversals of this graph.
 
 ## How is it used on Twitter
 UTG recommends tweets based on collaborative filtering & random walks. UTG takes a set of seed users or seed tweets as input, and performs

--- a/src/scala/com/twitter/recos/user_user_graph/README.md
+++ b/src/scala/com/twitter/recos/user_user_graph/README.md
@@ -1,7 +1,7 @@
 # UserUserGraph (UUG)
 
 ## What is it
-User User Graph (UUG) is a Finalge thrift service built on the GraphJet framework. In maintains a graph of user-user relationships and serves user recommendations based on traversals of this graph.
+User User Graph (UUG) is a Finagle thrift service built on the GraphJet framework. It maintains a graph of user-user relationships and serves user recommendations based on traversals of this graph.
 
 ## How is it used on Twitter
 UUG recommends users to follow based on who your follow graph have recently followed.

--- a/src/scala/com/twitter/recos/user_user_graph/README.md
+++ b/src/scala/com/twitter/recos/user_user_graph/README.md
@@ -6,7 +6,7 @@ User User Graph (UUG) is a Finagle thrift service built on the GraphJet framewor
 ## How is it used on Twitter
 UUG recommends users to follow based on who your follow graph have recently followed.
 The core idea behind UUG is collaborative filtering. UUG takes a user's weighted follow graph (i.e a list of weighted userIds) as input, 
-performs efficient traversal & aggregation, and returns the top weighted users basd on # of users that engaged the users, as well as 
+performs efficient traversal & aggregation, and returns the top weighted users based on # of users that engaged the users, as well as 
 the engaging users' weights.
 
 UUG is a stateful service and relies on a Kafka stream to ingest & persist states. It maintains an in-memory user engagements over the past 

--- a/src/scala/com/twitter/recos/user_video_graph/README.md
+++ b/src/scala/com/twitter/recos/user_video_graph/README.md
@@ -1,7 +1,7 @@
 # UserVideoGraph (UVG)
 
 ## What is it
-User Video Graph (UVG) is a Finalge thrift service built on the GraphJet framework. In maintains a graph of user-video engagements and serves user recommendations based on traversals in this graph.
+User Video Graph (UVG) is a Finagle thrift service built on the GraphJet framework. It maintains a graph of user-video engagements and serves user recommendations based on traversals in this graph.
 
 ## How is it used on Twitter
 UVG generates video recommendations from a given seed tweet set. It recommends tweets based on collaborative filtering & random walks.


### PR DESCRIPTION
## Description
Fixes multiple typos in documentation across GraphJet service README files and the retrieval signals reference doc.

## Changes
- RETREIVAL_SIGNALS.md: "bottom" → "button" (6 occurrences)
- user_tweet_graph/README.md: "Finalge" → "Finagle", "In maintains" → "It maintains"
- user_video_graph/README.md: "Finalge" → "Finagle", "In maintains" → "It maintains"
- user_user_graph/README.md: "Finalge" → "Finagle", "In maintains" → "It maintains", "basd" → "based"
- user_tweet_entity_graph/README.md: "Finalge" → "Finagle"

Documentation-only; no behavior changes.