### PR TITLE
Typo Fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Product surfaces at X are built on a shared set of data, models, and software fr
 | Software framework | [navi](navi/README.md) | High performance, machine learning model serving written in Rust. |
 |                    | [product-mixer](product-mixer/README.md) | Software framework for building feeds of content. |
 |                    | [timelines-aggregation-framework](timelines/data_processing/ml_util/aggregation_framework/README.md) | Framework for generating aggregate features in batch or real time. |
-|                    | [representation-manager](representation-manager/README.md) | Service to retrieve embeddings (i.e. SimClusers and TwHIN). |
+|                    | [representation-manager](representation-manager/README.md) | Service to retrieve embeddings (i.e. SimClusters and TwHIN). |
 |                    | [twml](twml/README.md) | Legacy machine learning framework built on TensorFlow v1. |
 
 The product surfaces currently included in this repository are the For You Timeline and Recommended Notifications.


### PR DESCRIPTION
This PR corrects a spelling error in the "Architecture" table of the README.md file. The term "SimClusers" appears to be a typo and is inconsistent with "SimClusters" used in other parts of the document.

## Changes
- In the "Architecture" table, under "representation-manager":
  - Original: "Service to retrieve embeddings (i.e. SimClusers and TwHIN)."
  - Updated: "Service to retrieve embeddings (i.e. SimClusters and TwHIN)."

## Motivation
Spotted this while reviewing the algorithm. No other changes are included in this PR to keep it focused.

These changes should make the README more accessible and understandable for all users.

Please let me know if you have any feedback or questions about these changes.